### PR TITLE
Workers requested features (Soft Ban)

### DIFF
--- a/src/VahterBanBot/Program.fs
+++ b/src/VahterBanBot/Program.fs
@@ -151,7 +151,7 @@ if botConf.UsePolling then
         new IUpdateHandler with
           member x.HandleUpdateAsync (botClient: ITelegramBotClient, update: Update, cancellationToken: CancellationToken) =
             task {
-                if not (isNull update.Message) && update.Message.Type = MessageType.Text then
+                if update.Message <> null && update.Message.Type = MessageType.Text then
                     let ctx = app.Services.CreateScope()
                     let logger = ctx.ServiceProvider.GetRequiredService<ILogger<IUpdateHandler>>()
                     let client = ctx.ServiceProvider.GetRequiredService<ITelegramBotClient>()

--- a/src/VahterBanBot/Types.fs
+++ b/src/VahterBanBot/Types.fs
@@ -14,7 +14,8 @@ type BotConfiguration =
       ChatsToMonitor: Dictionary<string, int64>
       AllowedUsers: Dictionary<string, int64>
       ShouldDeleteChannelMessages: bool
-      IgnoreSideEffects: bool }
+      IgnoreSideEffects: bool
+      UsePolling: bool }
 
 [<CLIMutable>]
 type DbUser =


### PR DESCRIPTION
# Preface

`/ban` command like a shotgun - blows head away. We need something less lethal but still effective

This pull-request adds `/sban` command that apply RO rules to user
As a bonus this PR have USE_POLLING flag to make local development easier

# Soft Ban Usage

Syntax:
```
/sban ?duration
```

## Example

Someone in the chat fooling around and need to be calmed down for a bit

Reply on user and command a bot:

```
/sban 69
```

or if one day (24hrs) is enough command this:

```
/sban
```
# USE_POLLING

To make development easier I added `USE_POLLING` environment

[Getting Updates at Telegram.Bot library docs](https://telegrambots.github.io/book/3/updates/index.html#getting-updates)

This intended to use only in local dev environment!
