### PR TITLE
added tables to mark messages as false negative

### DIFF
--- a/src/migrations/V6__false-banned.sql
+++ b/src/migrations/V6__false-banned.sql
@@ -1,0 +1,21 @@
+CREATE TABLE false_positive_users
+(
+    user_id BIGINT PRIMARY KEY
+        REFERENCES "user" (id) ON DELETE CASCADE
+);
+
+CREATE TABLE false_positive_messages
+(
+    chat_id    BIGINT NOT NULL,
+    message_id INT    NOT NULL,
+    PRIMARY KEY (chat_id, message_id),
+    FOREIGN KEY (chat_id, message_id) REFERENCES "message" (chat_id, message_id) ON DELETE CASCADE
+);
+
+CREATE TABLE false_negative_messages
+(
+    chat_id    BIGINT NOT NULL,
+    message_id INT    NOT NULL,
+    PRIMARY KEY (chat_id, message_id),
+    FOREIGN KEY (chat_id, message_id) REFERENCES "message" (chat_id, message_id) ON DELETE CASCADE
+);


### PR DESCRIPTION
this PR adds few aux tables to mark users or messages as false-positively/negatively banned

There is no table for false negatively banned users as all spammer accounts are short-lived