### PR TITLE
Fix log message formatting

### DIFF
--- a/src/VahterBanBot/Bot.fs
+++ b/src/VahterBanBot/Bot.fs
@@ -399,7 +399,7 @@ let killSpammerAutomated
             |> DB.banUserByBot
 
     let msgType = if deleteMessage then "Deleted" else "Detected"
-    let logMsg = $"""{msgType} spam (score: {score}) in {prependUsername message.Chat.Username} ({message.Chat.Id}) from {prependUsername message.From.Username} ({message.From.Id}) with text:\n{message.Text}"""
+    let logMsg = $"{msgType} spam (score: {score}) in {prependUsername message.Chat.Username} ({message.Chat.Id}) from {prependUsername message.From.Username} ({message.From.Id}) with text:\n{message.Text}"
 
     // log both to logger and to logs channel
     do! botClient.SendTextMessageAsync(ChatId(botConfig.LogsChannelId), logMsg) |> taskIgnore


### PR DESCRIPTION
Without this, `\n` was treated literally as two separate characters.