### PR TITLE
More robust testing

### DIFF
--- a/src/VahterBanBot.Tests/Logging.fs
+++ b/src/VahterBanBot.Tests/Logging.fs
@@ -1,0 +1,16 @@
+﻿namespace VahterBanBot.Tests
+
+open System
+open Microsoft.Extensions.Logging
+
+type StringLogger() =
+    let lockObj = obj()
+    let messages = ResizeArray<string>() 
+    interface ILogger with
+        member this.BeginScope _ = null
+        member this.IsEnabled _ = true
+        member this.Log(logLevel, _eventId, state, ex, formatter) =
+            lock lockObj (fun() ->
+                messages.Add($"[{logLevel}] {formatter.Invoke(state, ex)}"))
+
+    member _.ExtractMessages(): string = lock lockObj (fun() -> String.Join("\n", messages))

--- a/src/VahterBanBot.Tests/VahterBanBot.Tests.fsproj
+++ b/src/VahterBanBot.Tests/VahterBanBot.Tests.fsproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <Content Include="test_seed.sql" CopyToOutputDirectory="PreserveNewest" />
         <Compile Include="TgMessageUtils.fs" />
+        <Compile Include="Logging.fs" />
         <Compile Include="ContainerTestBase.fs" />
         <Compile Include="BaseTests.fs" />
         <Compile Include="MessageTests.fs" />


### PR DESCRIPTION
1. Now we produce container build logs on build failure (was tricky to implement but I checked and it works).
2. Added `.WithDeleteIfExists(true)` to prevent wrong reuse of an obsolete app container for testing.
3. We only collect logs from the `appContainer` if its state is not `Undefined` (I have to note I didn't check if this log collector still works, sorry).