### PR TITLE
Ban messages which have empty mentions (i.e. mentions with no text)

### DIFF
--- a/src/VahterBanBot/Bot.fs
+++ b/src/VahterBanBot/Bot.fs
@@ -531,6 +531,13 @@ let justMessage
                     // not a spam
                     ()
             | None ->
+                let shouldDelete =
+                    message.Entities
+                     |> Array.exists (fun x -> (x.Type = Enums.MessageEntityType.TextMention || x.Type= Enums.MessageEntityType.Mention)  && x.Length = 0)
+                if shouldDelete then
+                    // delete message
+                    do! killSpammerAutomated botClient botConfig message logger botConfig.MlSpamDeletionEnabled 0.0
+                else
                 // no prediction (error or not ready yet)
                 ()
 


### PR DESCRIPTION
This might be handy for cases when for whatever reason message is not marked as spam, but still has other spam conditions(i.e. mention a lot of people with empty text)