### PR TITLE
Spammers with the same username will be banned

### DIFF
--- a/src/migrations/V11__drop-username-unique.sql
+++ b/src/migrations/V11__drop-username-unique.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS user_username_uindex;
+
+CREATE INDEX user_username_index ON "user" (username);


### PR DESCRIPTION
Due to a brain fart, usernames were unique for no reason at all, therefore both users with duplicate usernames and their messages weren't recorded in vahter-db with 
```
Npgsql.PostgresException (0x80004005): 23505: duplicate key value violates unique constraint "user_username_uindex"

DETAIL: Key (username)=(some_username) already exists.
```

fixed by dropping unique constraint