### PR TITLE
Chats without username should not throw error on ban

### DIFF
--- a/src/VahterBanBot.Tests/MLBanTests.fs
+++ b/src/VahterBanBot.Tests/MLBanTests.fs
@@ -249,5 +249,18 @@ type MLBanTests(fixture: VahterTestContainers, _unused: MlAwaitFixture) =
         Assert.True msgBanned
     }
 
+    [<Fact>]
+    let ``Bans in chat without username should work`` () = task {
+        // record a message in a chat without username
+        let chat = Tg.chat(id = fixture.ChatsToMonitor[0].Id, username = null)
+        
+        let msgUpdate = Tg.quickMsg(chat = chat, text = "2222222")
+        let! _ = fixture.SendMessage msgUpdate
+
+        // assert that the message got auto banned
+        let! msgBanned = fixture.MessageIsAutoDeleted msgUpdate.Message
+        Assert.True msgBanned
+    }
+
     interface IAssemblyFixture<VahterTestContainers>
     interface IClassFixture<MlAwaitFixture>

--- a/src/VahterBanBot/Types.fs
+++ b/src/VahterBanBot/Types.fs
@@ -79,7 +79,7 @@ module DbBanned =
           banned_user_id = message.From.Id
           banned_at = DateTime.UtcNow
           banned_in_chat_id = Some message.Chat.Id
-          banned_in_chat_username = Some message.Chat.Username
+          banned_in_chat_username = Option.ofObj message.Chat.Username
           banned_by = vahter }
 
 [<CLIMutable>]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8940f4da-2966-457d-989b-24ba9af9fef3)

Problem as updates from chat comes without username:
```json
        "chat": {
            "id": -1001653630893,
            "type": "supergroup",
            "title": "Собрание",
            "is_forum": false
        },
```

Therefore this code below produces `Some null` which cannot be deciphered correctly by Dapper mappers
```fsharp
banned_in_chat_username = Some message.Chat.Username
```

Fix is trivial, running tests first